### PR TITLE
Added "load_stats" and "load_stats_ref" methods.

### DIFF
--- a/eg/manage.pl
+++ b/eg/manage.pl
@@ -19,7 +19,7 @@ print <<END_HELP
 
 Usage: manage.pl <hostname/IP> <port> <password> <command> [argument]
 
-Commands: auth-retry, echo, help, hold, kill, log, mute, signal, state, verb, version
+Commands: auth-retry, echo, help, hold, kill, load-stats, log, mute, signal, state, verb, version
 
 END_HELP
 ;

--- a/eg/manage.pl
+++ b/eg/manage.pl
@@ -24,7 +24,7 @@ Commands: auth-retry, echo, help, hold, kill, log, mute, signal, state, verb, ve
 END_HELP
 ;
 exit 1;
-}		
+}
 
 my $vpn = Net::OpenVPN::Manage->new({host=>$host, port=>$port, password=>$password, timeout=>5});
 unless ($vpn->connect()){
@@ -43,6 +43,8 @@ if ( $cmd eq 'auth-retry' ){
   $return = $vpn->hold($arg);
 } elsif ( $cmd eq 'kill' ){
   $return = $vpn->kill($arg);
+} elsif ( $cmd eq 'load-stats') {
+  $return = $vpn->load_stats();
 } elsif ( $cmd eq 'log' ){
   $return = $vpn->log($arg);
 } elsif ( $cmd eq 'mute' ){

--- a/eg/vpnclients.pl
+++ b/eg/vpnclients.pl
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Net::OpenVPN::Manage;
+use 5.010;
+
+my $vpn = Net::OpenVPN::Manage->new({
+        host => shift || 'localhost',
+        port => shift || 5000
+});
+
+unless ($vpn->connect()) {
+    say $vpn->{error_msg};
+    exit 2;
+}
+
+my $sref = $vpn->status_ref();
+my $lref = $vpn->load_stats_ref();
+
+if ( $lref->{nclients} > 0 ) {
+    for (my $i = 0; $i < $lref->{nclients}; $i++) {
+        printf("%2s %-16s: %-29s\n","",
+            ${$sref->{HEADER}{CLIENT_LIST}}[0],
+            ${$sref->{CLIENT_LIST}}[$i][0]);
+        printf("%2s %-16s: %-29s\n","",
+            ${$sref->{HEADER}{CLIENT_LIST}}[2],
+            ${$sref->{CLIENT_LIST}}[$i][2]);
+        printf("%2s %-16s: %-29s\n","",
+            ${$sref->{HEADER}{CLIENT_LIST}}[1],
+            ${$sref->{CLIENT_LIST}}[$i][1]);
+        printf("%2s %-16s: %-29s\n","",
+            ${$sref->{HEADER}{CLIENT_LIST}}[5],
+            ${$sref->{CLIENT_LIST}}[$i][5]);
+        printf("%2s %-16s: %-29s\n","",
+            ${$sref->{HEADER}{ROUTING_TABLE}}[3],
+            ${$sref->{ROUTING_TABLE}}[$i][3]);
+        print "\n";
+    }
+}
+else {
+    print "No clients are currently connected.\n";
+    exit 1;
+}
+

--- a/lib/Net/OpenVPN/Manage.pm
+++ b/lib/Net/OpenVPN/Manage.pm
@@ -93,8 +93,8 @@ sub kill($) {
   return $telnet->last_prompt();
 }
 
-# $hash_ref = $vpn->load_stats();
-sub load_stats {
+# $hash_ref = $vpn->load_stats_ref();
+sub load_stats_ref {
   my $href;
   my $self = shift;
   my $telnet = $self->{objects}{_telnet_};

--- a/lib/Net/OpenVPN/Manage.pm
+++ b/lib/Net/OpenVPN/Manage.pm
@@ -93,6 +93,18 @@ sub kill($) {
   return $telnet->last_prompt();
 }
 
+# $result =  $vpn->load_stats();
+sub load_stats {
+  my $self = shift;
+  my $telnet = $self->{objects}{_telnet_};
+  $telnet->cmd(String => 'load-stats', Prompt => '/(SUCCESS:.*\n|ERROR:.*\n)/');
+  unless ($telnet->last_prompt =~ /SUCCESS:.*/){
+    $self->{error_msg} = $telnet->last_prompt();
+    return 0;
+  }
+  return $telnet->last_prompt();
+}
+
 # $hash_ref = $vpn->load_stats_ref();
 sub load_stats_ref {
   my $href;


### PR DESCRIPTION
Added "load_stats" method to get raw output of the "load-stats" command (since OpenVPN 2.1), and  a "load_stats_ref" method, which returns parsed "load-stats" data as a reference to hash. 

I am currently using it with OpenVPN v2.3.2.
